### PR TITLE
Php8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,24 +7,30 @@ on:
   pull_request:
 jobs:
   Clone-install-test:
-    name: Test on PHP ${{ matrix.php-versions }} ${{ matrix.composer-update-param  }}
+    name: Test on PHP ${{ matrix.php-version }} ${{ matrix.composer-update-param  }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         composer-update-param: ['']
-        php-versions:
+        php-version:
           - 5.6
           - 7.0
           - 7.1
           - 7.2
           - 7.3
           - 7.4
+          - 8.0
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+          - 8.5
         include:
-          - php-versions: 5.6
+          - php-version: 5.6
             composer-update-param: '--prefer-lowest'
-          - php-versions: 7.4
-            composer-update-param: '--prefer-lowest' 
+          - php-version: 7.4
+            composer-update-param: '--prefer-lowest'
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -32,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
 
       - name: Get composer cache directory
@@ -49,9 +55,13 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
+      - name: Downgrade tests code for old PHP versions
+        if: ${{ matrix.php-version < 7.1 }}
+        run: composer downgrate-tests
+
       - name: Downgrade to lowest Composer versions
         if: ${{ matrix.composer-update-param }}
         run: composer update ${{ matrix.composer-update-param }} --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/simple-phpunit

--- a/Tests/DBAL/Types/CubeTypeTest.php
+++ b/Tests/DBAL/Types/CubeTypeTest.php
@@ -20,7 +20,7 @@ class CubeTypeTest extends TestCase
 
     private $platform;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!Type::hasType('cube')) {
             Type::addType('cube', CubeType::class);

--- a/Tests/DBAL/Types/EnumTypeTest.php
+++ b/Tests/DBAL/Types/EnumTypeTest.php
@@ -17,7 +17,7 @@ class EnumTypeTest extends TestCase
 
     private $platform;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!Type::hasType('enum')) {
             Type::addType('enum', EnumType::class);

--- a/Tests/DBAL/Types/MysqlBinaryHashTypeTest.php
+++ b/Tests/DBAL/Types/MysqlBinaryHashTypeTest.php
@@ -19,7 +19,7 @@ final class MysqlBinaryHashTypeTest extends TestCase
     /** @var MySqlPlatform */
     private $platform;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $typeName = BinaryHashType::TYPE_NAME;
 

--- a/Tests/DBAL/Types/UnescapedJsonTypeTest.php
+++ b/Tests/DBAL/Types/UnescapedJsonTypeTest.php
@@ -17,7 +17,7 @@ class UnescapedJsonTypeTest extends TestCase
 
     private $platform;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists(JsonType::class)) {
             $this->markTestSKipped('Class JsonType not yet exists');

--- a/Tests/ORM/OrmTestCase.php
+++ b/Tests/ORM/OrmTestCase.php
@@ -8,7 +8,7 @@ abstract class OrmTestCase extends TestCase
 {
     protected $entityManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
         $config->setProxyDir(sys_get_temp_dir().'/DoctrineTestsProxies');

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -2,17 +2,15 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-if (!class_exists(Doctrine\DBAL\Platforms\MySqlPlatform::class)) {
+if (class_exists(Doctrine\DBAL\Platforms\MySQLPlatform::class) && !class_exists(Doctrine\DBAL\Platforms\MySqlPlatform::class)) {
     class_alias(Doctrine\DBAL\Platforms\MySQLPlatform::class, Doctrine\DBAL\Platforms\MySqlPlatform::class);
 }
 
-if (!class_exists(Doctrine\DBAL\Platforms\PostgreSQL92Platform::class)) {
-    if (class_exists(Doctrine\DBAL\Platforms\PostgreSQLPlatform::class)) {
-        class_alias(Doctrine\DBAL\Platforms\PostgreSQLPlatform::class, Doctrine\DBAL\Platforms\PostgreSQL92Platform::class);
-    }
-    if (class_exists(Doctrine\DBAL\Platforms\PostgreSqlPlatform::class)) {
-        class_alias(Doctrine\DBAL\Platforms\PostgreSqlPlatform::class, Doctrine\DBAL\Platforms\PostgreSQL92Platform::class);
-    }
+if (class_exists(Doctrine\DBAL\Platforms\PostgreSQLPlatform::class) && !class_exists(Doctrine\DBAL\Platforms\PostgreSQL92Platform::class)) {
+    class_alias(Doctrine\DBAL\Platforms\PostgreSQLPlatform::class, Doctrine\DBAL\Platforms\PostgreSQL92Platform::class);
+}
+if (class_exists(Doctrine\DBAL\Platforms\PostgreSqlPlatform::class) && !class_exists(Doctrine\DBAL\Platforms\PostgreSQL92Platform::class)) {
+    class_alias(Doctrine\DBAL\Platforms\PostgreSqlPlatform::class, Doctrine\DBAL\Platforms\PostgreSQL92Platform::class);
 }
 
 if (!class_exists(Doctrine\DBAL\Driver\PDOMySql\Driver::class)) {

--- a/composer.json
+++ b/composer.json
@@ -8,20 +8,21 @@
         }
     },
     "require" : {
-        "php" : "^5.5 || ^7.0",
+        "php" : "^5.5 || ^7.0 || ^8.0",
         "doctrine/doctrine-bundle" : "^1.6 || ^2.0",
         "doctrine/orm" : "^2.5.14"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^5.7.27 || ^6",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/yaml" : "^3 || ^4 || ^5",
+        "symfony/phpunit-bridge": ">=5.2.12",
+        "symfony/dependency-injection": "^3.4 || ^4 || ^5 || ^6",
+        "symfony/yaml" : "^3 || ^4 || ^5 || ^6",
         "doctrine/annotations": "^1.0 || ^2.0"
     },
     "scripts" : {
         "fix": "php-cs-fixer fix --config=.php_cs.dist $(git ls-files '*.php') $(git ls-files --exclude-standard --others '*.php')",
         "f": "@fix",
-        "test": "phpunit --columns max --color=always",
+        "test": "simple-phpunit --columns max --color=always",
+        "downgrate-tests": "sed -i 's/: void//' $(git grep -l ': void' Tests/)",
         "coverage": "phpdbg -qrr vendor/bin/phpunit --coverage-html ./.coverage --coverage-text"
     },
     "license" : "MIT",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
-    backupStaticAttributes="false" bootstrap="Tests/bootstrap.php" colors="true" convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" cacheResult="false">
-
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Doctrine custom types bundle test suite">
-            <directory suffix="Test.php">./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>DBAL</directory>
-            <directory>DependencyInjection</directory>
-            <directory>EventListener</directory>
-            <directory>ORM</directory>
-            <directory>Value</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="Tests/bootstrap.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    cacheResult="false">
+  <coverage>
+    <include>
+      <directory>DBAL</directory>
+      <directory>DependencyInjection</directory>
+      <directory>EventListener</directory>
+      <directory>ORM</directory>
+      <directory>Value</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+  </php>
+  <testsuites>
+    <testsuite name="Doctrine custom types bundle test suite">
+      <directory suffix="Test.php">./Tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
- Use symfony's phpunit bridge
- Improve class aliases processing (since 8.x class name case ignored)
- Add php versions 8.x
- Add php8 version to allowed in composer
- Upgrade tests code for latest phpunit's and downgrade em for too old php versions
- Add min 5.2.12 for symfony phpunit bridge with prefer-lowest